### PR TITLE
JUnitのバージョンを現行バージョンにアップ

### DIFF
--- a/en/java/staticanalysis/checkstyle/checkstyle-example/pom.xml
+++ b/en/java/staticanalysis/checkstyle/checkstyle-example/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/staticanalysis/checkstyle/checkstyle-example/pom.xml
+++ b/java/staticanalysis/checkstyle/checkstyle-example/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
+++ b/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
# 概要

* 以下の修正を適用したいため、JUnit4のバージョンを上げました。
  https://github.com/junit-team/junit4/blob/HEAD/doc/ReleaseNotes4.13.1.md#security-fix-temporaryfolder-now-limits-access-to-temporary-folders-on-java-17-or-later
* 依存関係の修正のみです。
* 本PRはリリース対象です。本リポジトリは利用者がビルドする想定であるため。